### PR TITLE
Improve install-arch.sh and install-gentoo.sh with clear instructions and optimizations.

### DIFF
--- a/install-arch.sh
+++ b/install-arch.sh
@@ -31,13 +31,13 @@ if ! command -v yay &> /dev/null; then
     sudo pacman -Syu --needed base-devel git
     git clone https://aur.archlinux.org/yay.git ~/yay
     (cd ~/yay && makepkg -si)
+    rm -rf ~/yay
 fi
 
 # Install dependencies
 echo ""
 if ask_yn "Do you want to install required dependencies (very recommended)?"; then
-    sudo pacman -Syu
-    yay -S hyprland waybar waypaper swww rofi-wayland swaync python-pipx nemo kitty pavucontrol gtk2 gtk3 nwg-look fastfetch zsh nerd-fonts-complete networkmanager networkmanager-qt nm-connection-editor xcur2png gsettings-qt hyprshot wlogout ttf-fira-sans ttf-firecode-nerd otf-droid-nerd texlive-fontsextra
+    yay -Syu hyprland waybar waypaper swww rofi-wayland swaync python-pipx nemo kitty pavucontrol gtk2 gtk3 nwg-look fastfetch zsh nerd-fonts-complete networkmanager networkmanager-qt nm-connection-editor xcur2png gsettings-qt hyprshot wlogout ttf-fira-sans ttf-firecode-nerd otf-droid-nerd texlive-fontsextra
 else
     echo "Skipping dependency installation..."
 fi
@@ -73,16 +73,10 @@ copy_with_backup() {
     cp -rf "$src" "$dest"
 }
 
-echo "Copying .config to ~/.config"
+echo "Backing up existing configurations to $BACKUP_DIR"
 copy_with_backup "$SCRIPT_DIR/.config/" "$HOME/.config/"
-
-echo "Copying .zshrc to ~/.zshrc"
 copy_with_backup "$SCRIPT_DIR/.zshrc" "$HOME/.zshrc"
-
-echo "Copying wallpaper to ~/wallpaper"
 copy_with_backup "$SCRIPT_DIR/wallpaper" "$HOME/wallpaper"
-
-echo "Copying .themes to ~/.themes"
 copy_with_backup "$SCRIPT_DIR/.themes/" "$HOME/.themes/"
 
 # Nerd Fonts
@@ -90,6 +84,7 @@ echo ""
 if ask_yn "Do you want to install Nerd Fonts (Recommended) (~8GB download)?"; then
     git clone --depth=1 https://github.com/ryanoasis/nerd-fonts.git ~/nerd-fonts
     ~/nerd-fonts/install.sh
+    rm -rf ~/nerd-fonts
 else
     echo "Skipping Nerd Fonts installation..."
 fi

--- a/install-gentoo.sh
+++ b/install-gentoo.sh
@@ -41,7 +41,7 @@ choice=$(ask_choice "Which distro do you have?: (1) Arch Linux, (2) Gentoo Linux
 
 case $choice in
     1)
-        echo "Arch Linux not implemented yet."
+        echo "Please use install-arch.sh for Arch Linux."
         ;;
     2)
         # Loop to choose doas or sudo with validation


### PR DESCRIPTION
This pull request includes several changes to the `install-arch.sh` and `install-gentoo.sh` scripts to improve the installation process and clean up the code. The most important changes include adding cleanup steps after installations, modifying dependency installation commands, and updating user prompts.

Improvements and cleanups:

* [`install-arch.sh`](diffhunk://#diff-97d0bb5f37f70d569608a5a1d6c3b3e1e5824b50101b25a16de57168ac81f425R34-R40): Added a command to remove the `yay` directory after installation to clean up temporary files.
* [`install-arch.sh`](diffhunk://#diff-97d0bb5f37f70d569608a5a1d6c3b3e1e5824b50101b25a16de57168ac81f425L76-R87): Added a command to remove the `nerd-fonts` directory after installation to clean up temporary files.

Dependency installation:

* [`install-arch.sh`](diffhunk://#diff-97d0bb5f37f70d569608a5a1d6c3b3e1e5824b50101b25a16de57168ac81f425R34-R40): Modified the dependency installation command to use `yay -Syu` instead of running `sudo pacman -Syu` followed by `yay -S`. This simplifies the process and ensures all packages are updated and installed in one step.

User prompts and messages:

* [`install-arch.sh`](diffhunk://#diff-97d0bb5f37f70d569608a5a1d6c3b3e1e5824b50101b25a16de57168ac81f425L76-R87): Updated the script to provide a clearer message when backing up existing configurations.
* [`install-gentoo.sh`](diffhunk://#diff-c12fd04435e340f3d665d0ddc309fc96dd778f6d497072f16dfd3b8b2269aa40L44-R44): Updated the prompt for Arch Linux users to direct them to use the `install-arch.sh` script instead.