### PR TITLE
Improve Arch-install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Huge thanks to [Ksawlii](https://github.com/Ksawlii) and [Thomas Brugman](https:
 > [!NOTE]
 > This installation script is currently limited to Gentoo and Arch (and derivatives of Arch), and is not 100% done. Some features may need to be configured manually.
 
+> [!WARNING]
+> Do not run `yay` or `paru` as root. Running these AUR helpers as root can cause permanent damage to your system. Always run them as a regular user.
+
 # Manual Installation
 
 1. Install the dependencies with your preffered AUR helper:
@@ -59,13 +62,13 @@ Huge thanks to [Ksawlii](https://github.com/Ksawlii) and [Thomas Brugman](https:
 For yay:
 
 ```
-yay -S hyprland wlogout waypaper waybar swww rofi-wayland swaync nemo kitty pavucontrol gtk3 gtk2 xcur2png gsettings nwg-look fastfetch zsh oh-my-zsh-git hyprshot networkmanager networkmanager-qt nm-connection-editor
+yay -S hyprland wlogout waypaper waybar swww rofi-wayland swaync nemo kitty pavucontrol gtk3 gtk2 xcur2png gsettings nwg-look fastfetch zsh oh-my-zsh-git hyprshot networkmanager networkmanager-qt nm-connection-editor ttf-firacode-nerd nerd-fonts-jetbrains-mono
 ```
 
 For paru:
 
 ```
-paru -S hyprland wlogout waypaper waybar swww rofi-wayland swaync nemo kitty pavucontrol gtk3 gtk2 xcur2png gsettings nwg-look fastfetch zsh oh-my-zsh-git hyprshot networkmanager networkmanager-qt nm-connection-editor
+paru -S hyprland wlogout waypaper waybar swww rofi-wayland swaync nemo kitty pavucontrol gtk3 gtk2 xcur2png gsettings nwg-look fastfetch zsh oh-my-zsh-git hyprshot networkmanager networkmanager-qt nm-connection-editor ttf-firacode-nerd nerd-fonts-jetbrains-mono
 ```
 
 2. Clone the repository with:


### PR DESCRIPTION
This pull request includes updates to the `README.md` file and significant improvements to the `install-arch.sh` script to enhance error handling and ensure proper installation processes.

### Documentation Update:
* Added a warning in `README.md` about not running `yay` or `paru` as root to prevent system damage.

### Script Enhancements:
* Added functions `error_exit` and `command_exists` in `install-arch.sh` to handle errors and check command existence.
* Implemented a check to prevent the script from being run as root, with an appropriate error message.
* Modified the script to use the `command_exists` function for detecting `yay` and `paru` and added error handling for their installation processes.
* Added checks to create necessary directories if they do not exist before copying configurations.
* Updated the Nerd Fonts installation process to include error handling.